### PR TITLE
feat: タスク編集機能の実装

### DIFF
--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -2,12 +2,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
 
-// ✅ Next.js App Router対応: params取得をasyncに修正
 export async function DELETE(
   request: NextRequest,
   context: { params: { id?: string } }
 ) {
-  // paramsを非同期で取得
   const { id } = await context.params;
 
   if (!id) {
@@ -17,7 +15,6 @@ export async function DELETE(
 
   console.log(`🗑️ 削除対象タスクID: ${id}`);
 
-  // Supabaseからタスクを削除
   const { error } = await supabase.from('tasks').delete().eq('id', id);
 
   if (error) {
@@ -30,4 +27,41 @@ export async function DELETE(
 
   console.log('✅ タスクが削除されました:', id);
   return NextResponse.json({ message: '✅ タスクが削除されました' });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: { id?: string } }
+) {
+  const { id } = await context.params;
+
+  if (!id) {
+    return NextResponse.json({ error: 'タスクIDは必須です' }, { status: 400 });
+  }
+
+  try {
+    const { title, description } = await request.json();
+
+    const { error } = await supabase
+      .from('tasks')
+      .update({ title, description, updatedAt: new Date() })
+      .eq('id', id);
+
+    if (error) {
+      console.error('🚨 Supabase 更新エラー:', error.message);
+      return NextResponse.json(
+        { error: `更新エラー: ${error.message}` },
+        { status: 500 }
+      );
+    }
+
+    console.log(`✅ タスク ${id} が更新されました`);
+    return NextResponse.json({ message: '✅ タスクが更新されました' });
+  } catch (error: any) {
+    console.error('🚨 サーバーエラー:', error.message);
+    return NextResponse.json(
+      { error: 'サーバーエラー', details: error.message },
+      { status: 500 }
+    );
+  }
 }

--- a/components/EditTaskForm.tsx
+++ b/components/EditTaskForm.tsx
@@ -1,0 +1,95 @@
+// src/components/EditTaskForm.tsx
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { mutate } from 'swr';
+
+interface EditTaskFormProps {
+  taskId: string;
+  currentTitle: string;
+  currentDescription?: string;
+  onClose: () => void;
+}
+
+export default function EditTaskForm({
+  taskId,
+  currentTitle,
+  currentDescription = '',
+  onClose,
+}: EditTaskFormProps) {
+  const [title, setTitle] = useState(currentTitle ?? '');
+  const [description, setDescription] = useState(currentDescription ?? '');
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleUpdate = async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, description }),
+      });
+      const data = await res.json();
+
+      if (res.ok) {
+        toast({
+          title: '✅ 更新成功',
+          description: 'タスクが更新されました！',
+        });
+        mutate('/api/tasks'); // 一覧を即時更新
+        onClose();
+      } else {
+        toast({
+          title: '❌ エラー',
+          description: data.error,
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: '❌ エラー',
+        description: '通信エラーが発生しました',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-6 rounded-lg shadow-lg w-96">
+        <h2 className="text-xl font-bold mb-4">✏️ タスクを編集</h2>
+        <Input
+          value={title ?? ''}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="タイトル"
+          className="mb-3"
+        />
+        <Textarea
+          value={description ?? ''}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="詳細"
+          className="mb-4"
+        />
+        <div className="flex justify-end gap-2">
+          <Button onClick={onClose} className="bg-gray-400">
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleUpdate}
+            disabled={isLoading}
+            className="bg-blue-500 text-white"
+          >
+            {isLoading ? '更新中...' : '更新'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -1,34 +1,31 @@
 // src/components/TaskList.tsx
 'use client';
 
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
-import { mutate } from 'swr';
+import { useState } from 'react';
+import EditTaskForm from './EditTaskForm';
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export default function TaskList() {
   const { data: tasks, error, isLoading } = useSWR('/api/tasks', fetcher);
   const { toast } = useToast();
+  const [editingTask, setEditingTask] = useState(null);
 
   // タスク削除ハンドラー
   const handleDeleteTask = async (taskId: string) => {
     try {
-      const res = await fetch(`/api/tasks/${taskId}`, {
-        method: 'DELETE',
+      const res = await fetch(`/api/tasks/${taskId}`, { method: 'DELETE' });
+      toast({
+        title: res.ok ? '🗑️ タスク削除' : '❌ エラー',
+        description: res.ok
+          ? 'タスクを削除しました'
+          : 'タスク削除に失敗しました',
+        variant: res.ok ? undefined : 'destructive',
       });
-
-      if (res.ok) {
-        toast({ title: '🗑️ タスク削除', description: 'タスクを削除しました' });
-        mutate('/api/tasks'); // 一覧を再取得
-      } else {
-        toast({
-          title: '❌ エラー',
-          description: 'タスク削除に失敗しました',
-          variant: 'destructive',
-        });
-      }
+      if (res.ok) mutate('/api/tasks');
     } catch {
       toast({
         title: '❌ エラー',
@@ -40,32 +37,48 @@ export default function TaskList() {
 
   if (isLoading) return <p>🌀 読み込み中...</p>;
   if (error) return <p>❌ エラーが発生しました</p>;
-  if (!tasks || tasks.length === 0) return <p>📭 タスクがありません</p>;
+  if (!tasks?.length) return <p>📭 タスクがありません</p>;
 
   return (
     <div className="p-4 bg-white rounded-lg shadow-md">
       <h2 className="text-xl font-bold mb-4">🗂️ タスク一覧</h2>
       <ul className="space-y-2">
-        {tasks.map((task: any) => (
+        {tasks.map(({ id, title, description }) => (
           <li
-            key={task.id}
+            key={id}
             className="p-2 border rounded-md flex justify-between items-center"
           >
             <div>
-              <strong>{task.title}</strong>
+              <strong>{title}</strong>
               <p className="text-sm text-gray-500">
-                {task.description || '詳細なし'}
+                {description || '詳細なし'}
               </p>
             </div>
-            <Button
-              onClick={() => handleDeleteTask(task.id)}
-              className="bg-red-500 text-white"
-            >
-              削除
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                onClick={() => setEditingTask({ id, title, description })}
+                className="bg-yellow-500 text-white"
+              >
+                編集
+              </Button>
+              <Button
+                onClick={() => handleDeleteTask(id)}
+                className="bg-red-500 text-white"
+              >
+                削除
+              </Button>
+            </div>
           </li>
         ))}
       </ul>
+      {editingTask && (
+        <EditTaskForm
+          taskId={editingTask.id}
+          currentTitle={editingTask.title}
+          currentDescription={editingTask.description}
+          onClose={() => setEditingTask(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- タスク編集用のAPIエンドポイント（PATCH /api/tasks/[id]）を追加
- タスク編集用モーダルコンポーネント（EditTaskForm）を新規作成
- タスク一覧（TaskList）に編集ボタンと編集機能を追加

タスクのタイトルと説明文を更新できる機能を実装。
モーダル形式のUIで編集を行い、即時に一覧に反映されるように実装。